### PR TITLE
Improved PostgreSQL Schema Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,16 @@ check the indexes on the table and delete any extra indexes and create any missi
 is done through the index name, so if you use custom names for your indexes, it might happen that it won't get updated
 on change of the content but not the name.
 
-### Custom Schema
+### Schemas
 
-You can define any table name you wish for your views. They can even live inside your own custom
-[PostgreSQL schema](http://www.postgresql.org/docs/current/static/ddl-schemas.html).
+By default, the views will get created in the schema of the database, this is usually `public`. 
+The package supports the database defining the schema in the settings by using 
+options (`"OPTIONS": {"options": "-c search_path=custom_schema"}`).
+
+The package `django-tenants` is supported as well, if used.
+
+It is possible to define the schema explicitly for a view, if different from the default schema of the database, like
+this: 
 
 ```python
 from django_pgviews import view as pg

--- a/tests/test_project/multidbtest/routers.py
+++ b/tests/test_project/multidbtest/routers.py
@@ -10,6 +10,8 @@ class WeatherPinnedRouter:
         """
         if model._meta.app_label == "multidbtest":
             return "weather_db"
+        if model._meta.app_label == "schemadbtest":
+            return "schema_db"
         return "default"
 
     def db_for_write(self, model, **hints):
@@ -18,13 +20,18 @@ class WeatherPinnedRouter:
         """
         if model._meta.app_label == "multidbtest":
             return "weather_db"
+        if model._meta.app_label == "schemadbtest":
+            return "schema_db"
         return "default"
 
     def allow_relation(self, obj1, obj2, **hints):
         """
         Allow relations if a model in the multidbtest app is involved.
         """
-        if obj1._meta.app_label == "multidbtest" or obj2._meta.app_label == "multidbtest":
+        if obj1._meta.app_label in {"multidbtest", "schemadbtest"} or obj2._meta.app_label in {
+            "multidbtest",
+            "schemadbtest",
+        }:
             return True
         return None
 
@@ -34,5 +41,7 @@ class WeatherPinnedRouter:
         """
         if app_label == "multidbtest":
             return db == "weather_db"
+        elif app_label == "schemadbtest":
+            return db == "schema_db"
         else:
             return db == "default"

--- a/tests/test_project/multidbtest/tests.py
+++ b/tests/test_project/multidbtest/tests.py
@@ -3,16 +3,14 @@ import datetime as dt
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.dispatch import receiver
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from django_pgviews.signals import view_synced
 
 from ..viewtest.models import RelatedView
 from .models import MonthlyObservation, Observation
-from .routers import WeatherPinnedRouter
 
 
-@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
 class WeatherPinnedViewConnectionTest(TestCase):
     """Weather views should only return weather_db when pinned."""
 
@@ -29,17 +27,6 @@ class WeatherPinnedViewConnectionTest(TestCase):
         self.assertEqual(RelatedView.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
 
 
-class DefaultRouterViewConnectionTest(TestCase):
-    """All views should should use default alias by default."""
-
-    def test_weather_view_default(self):
-        self.assertEqual(MonthlyObservation.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
-
-    def test_other_app_view_default(self):
-        self.assertEqual(RelatedView.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
-
-
-@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
 class WeatherPinnedRefreshViewTest(TestCase):
     """View.refresh() should automatically select the appropriate database."""
 
@@ -57,7 +44,6 @@ class WeatherPinnedRefreshViewTest(TestCase):
         self.assertEqual(MonthlyObservation.objects.count(), 1)
 
 
-@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
 class WeatherPinnedMigrateTest(TestCase):
     """Ensure views are only sync'd against the correct database on migrate."""
 
@@ -86,7 +72,6 @@ class WeatherPinnedMigrateTest(TestCase):
         self.assertNotIn(RelatedView, synced_views)
 
 
-@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
 class WeatherPinnedSyncPGViewsTest(TestCase):
     """Ensure views are only sync'd against the correct database with sync_pgviews."""
 
@@ -115,7 +100,6 @@ class WeatherPinnedSyncPGViewsTest(TestCase):
         self.assertNotIn(RelatedView, synced_views)
 
 
-@override_settings(DATABASE_ROUTERS=[WeatherPinnedRouter()])
 class WeatherPinnedRefreshPGViewsTest(TestCase):
     """Ensure views are only refreshed on each database using refresh_pgviews"""
 

--- a/tests/test_project/routers.py
+++ b/tests/test_project/routers.py
@@ -1,4 +1,4 @@
-class WeatherPinnedRouter:
+class DBRouter:
     """
     A router to control all database operations on models and views in the
     multidbtest application.

--- a/tests/test_project/schemadbtest/models.py
+++ b/tests/test_project/schemadbtest/models.py
@@ -1,0 +1,49 @@
+from django.db import connections, models
+from django.db.models import signals
+from django.dispatch import receiver
+
+from django_pgviews import view
+
+
+class SchemaObservation(models.Model):
+    date = models.DateField()
+    temperature = models.IntegerField()
+
+
+VIEW_SQL = """
+WITH summary AS (
+    SELECT
+        date_trunc('month', date) AS date,
+        count(*)
+    FROM schemadbtest_schemaobservation
+    GROUP BY 1
+    ORDER BY date
+) SELECT
+    ROW_NUMBER() OVER () AS id,
+    date,
+    count
+FROM summary;
+"""
+
+
+class SchemaMonthlyObservationView(view.View):
+    sql = VIEW_SQL
+    date = models.DateField()
+    count = models.IntegerField()
+
+
+class SchemaMonthlyObservationMaterializedView(view.MaterializedView):
+    sql = VIEW_SQL
+    date = models.DateField()
+    count = models.IntegerField()
+
+    class Meta:
+        managed = False
+        indexes = [models.Index(fields=["date"])]
+
+
+@receiver(signals.pre_migrate)
+def create_test_schema(sender, app_config, using, **kwargs):
+    command = "CREATE SCHEMA IF NOT EXISTS {};".format("other")
+    with connections[using].cursor() as cursor:
+        cursor.execute(command)

--- a/tests/test_project/schemadbtest/tests.py
+++ b/tests/test_project/schemadbtest/tests.py
@@ -1,0 +1,181 @@
+import datetime as dt
+from contextlib import closing
+
+from django.core.management import call_command
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.dispatch import receiver
+from django.test import TestCase
+
+from django_pgviews.signals import view_synced
+
+from ..viewtest.models import RelatedView
+from ..viewtest.tests import get_list_of_indexes
+from .models import SchemaMonthlyObservationMaterializedView, SchemaMonthlyObservationView, SchemaObservation
+
+
+class WeatherPinnedViewConnectionTest(TestCase):
+    """Weather views should only return schema_db when pinned."""
+
+    def test_schema_view_using_schema_db(self):
+        self.assertEqual(SchemaMonthlyObservationView.get_view_connection(using="schema_db"), connections["schema_db"])
+
+    def test_schema_view_using_default_db(self):
+        self.assertIsNone(SchemaMonthlyObservationView.get_view_connection(using=DEFAULT_DB_ALIAS))
+
+    def test_schema_materialized_view_using_schema_db(self):
+        self.assertEqual(
+            SchemaMonthlyObservationMaterializedView.get_view_connection(using="schema_db"), connections["schema_db"]
+        )
+
+    def test_schema_materialized_view_using_default_db(self):
+        self.assertIsNone(SchemaMonthlyObservationMaterializedView.get_view_connection(using=DEFAULT_DB_ALIAS))
+
+    def test_other_app_view_using_schema_db(self):
+        self.assertIsNone(RelatedView.get_view_connection(using="schema_db"))
+
+    def test_other_app_view_using_default_db(self):
+        self.assertEqual(RelatedView.get_view_connection(using=DEFAULT_DB_ALIAS), connections["default"])
+
+
+class SchemaTest(TestCase):
+    """View.refresh() should automatically select the appropriate schema."""
+
+    databases = {DEFAULT_DB_ALIAS, "schema_db"}
+
+    def test_schemas(self):
+        with closing(connections["schema_db"].cursor()) as cur:
+            cur.execute("""SELECT schemaname FROM pg_tables WHERE tablename LIKE 'schemadbtest_schemaobservation';""")
+
+            res = cur.fetchone()
+            self.assertIsNotNone(res, "Can't find table schemadbtest_schemaobservation;")
+
+            (schemaname,) = res
+            self.assertEqual(schemaname, "other")
+
+            cur.execute(
+                """SELECT schemaname FROM pg_views WHERE viewname LIKE 'schemadbtest_schemamonthlyobservationview';"""
+            )
+
+            res = cur.fetchone()
+            self.assertIsNotNone(res, "Can't find schemadbtest_schemamonthlyobservationview;")
+
+            (schemaname,) = res
+            self.assertEqual(schemaname, "other")
+
+            cur.execute(
+                """SELECT schemaname FROM pg_matviews WHERE matviewname LIKE 'schemadbtest_schemamonthlyobservationmaterializedview';"""
+            )
+
+            res = cur.fetchone()
+            self.assertIsNotNone(res, "Can't find schemadbtest_schemamonthlyobservationmaterializedview.")
+
+            (schemaname,) = res
+            self.assertEqual(schemaname, "other")
+
+            indexes = get_list_of_indexes(cur, SchemaMonthlyObservationMaterializedView)
+            self.assertEqual(indexes, {"schemadbtes_date_9985f7_idx"})
+
+    def test_view(self):
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 3), temperature=20)
+        self.assertEqual(SchemaMonthlyObservationView.objects.count(), 1)
+
+    def test_mat_view_pre_refresh(self):
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 3), temperature=20)
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 0)
+
+    def test_mat_view_refresh(self):
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 3), temperature=20)
+        SchemaMonthlyObservationMaterializedView.refresh()
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 1)
+
+    def test_view_exists_on_sync(self):
+        synced = []
+
+        @receiver(view_synced)
+        def on_view_synced(sender, **kwargs):
+            synced.append(sender)
+            if sender == SchemaMonthlyObservationView:
+                self.assertEqual(
+                    dict(
+                        {"status": "EXISTS", "has_changed": False},
+                        update=False,
+                        force=False,
+                        signal=view_synced,
+                        using="schema_db",
+                    ),
+                    kwargs,
+                )
+            if sender == SchemaMonthlyObservationMaterializedView:
+                self.assertEqual(
+                    dict(
+                        {"status": "UPDATED", "has_changed": True},
+                        update=False,
+                        force=False,
+                        signal=view_synced,
+                        using="schema_db",
+                    ),
+                    kwargs,
+                )
+
+        call_command("sync_pgviews", database="schema_db", update=False)
+
+        self.assertIn(SchemaMonthlyObservationView, synced)
+        self.assertIn(SchemaMonthlyObservationMaterializedView, synced)
+
+    def test_sync_pgviews_materialized_views_check_sql_changed(self):
+        self.assertEqual(SchemaObservation.objects.count(), 0, "Test started with non-empty SchemaObservation")
+        self.assertEqual(
+            SchemaMonthlyObservationMaterializedView.objects.count(), 0, "Test started with non-empty mat view"
+        )
+
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+
+        # test regular behaviour, the mat view got recreated
+        call_command("sync_pgviews", database="schema_db", update=False)  # uses default django setting, False
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 1)
+
+        # the mat view did not get recreated because the model hasn't changed
+        SchemaObservation.objects.create(date=dt.date(2022, 2, 3), temperature=20)
+        call_command("sync_pgviews", database="schema_db", update=False, materialized_views_check_sql_changed=True)
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 1)
+
+        # the mat view got recreated because the mat view SQL has changed
+
+        # let's pretend the mat view in the DB is ordered by name, while the defined on models isn't
+        with connections["schema_db"].cursor() as cursor:
+            cursor.execute("DROP MATERIALIZED VIEW schemadbtest_schemamonthlyobservationmaterializedview CASCADE;")
+            cursor.execute(
+                """
+                CREATE MATERIALIZED VIEW schemadbtest_schemamonthlyobservationmaterializedview as
+                WITH summary AS (
+                    SELECT
+                        date_trunc('day', date) AS date,
+                        count(*)
+                    FROM schemadbtest_schemaobservation
+                    GROUP BY 1
+                    ORDER BY date
+                ) SELECT
+                    ROW_NUMBER() OVER () AS id,
+                    date,
+                    count
+                FROM summary;
+                """
+            )
+
+        call_command("sync_pgviews", update=False, materialized_views_check_sql_changed=True)
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 2)
+
+    def test_migrate_materialized_views_check_sql_changed_default(self):
+        self.assertEqual(SchemaObservation.objects.count(), 0, "Test started with non-empty SchemaObservation")
+        self.assertEqual(
+            SchemaMonthlyObservationMaterializedView.objects.count(), 0, "Test started with non-empty mat view"
+        )
+
+        SchemaObservation.objects.create(date=dt.date(2022, 1, 1), temperature=10)
+
+        call_command("migrate", database="schema_db")
+
+        self.assertEqual(SchemaMonthlyObservationMaterializedView.objects.count(), 1)

--- a/tests/test_project/settings/base.py
+++ b/tests/test_project/settings/base.py
@@ -38,6 +38,7 @@ DATABASES = {
         "PORT": "",
     },
 }
+DATABASE_ROUTERS = ["test_project.routers.DBRouter"]
 
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tests/test_project/settings/base.py
+++ b/tests/test_project/settings/base.py
@@ -13,22 +13,29 @@ MANAGERS = ADMINS
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",  # Add 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        "NAME": "django_pgviews",  # Or path to database file if using sqlite3.
-        # The following settings are not used with sqlite3:
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "django_pgviews",
         "USER": "postgres",
         "PASSWORD": "postgres",
-        "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        "PORT": "",  # Set to empty string for default.
+        "HOST": "",
+        "PORT": "",
     },
     "weather_db": {
-        "ENGINE": "django.db.backends.postgresql",  # Add 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        "NAME": "postgres_weatherdb",  # Or path to database file if using sqlite3.
-        # The following settings are not used with sqlite3:
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "postgres_weatherdb",
         "USER": "django_pgviews",
         "PASSWORD": "postgres",
-        "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        "PORT": "",  # Set to empty string for default.
+        "HOST": "",
+        "PORT": "",
+    },
+    "schema_db": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "postgres_schemadb",
+        "OPTIONS": {"options": "-c search_path=other"},
+        "USER": "django_pgviews",
+        "PASSWORD": "postgres",
+        "HOST": "",
+        "PORT": "",
     },
 }
 
@@ -141,6 +148,7 @@ INSTALLED_APPS = (
     "django_pgviews",
     "test_project.viewtest",
     "test_project.multidbtest",
+    "test_project.schemadbtest",
 )
 
 # A sample logging configuration. The only tangible logging

--- a/tests/test_project/settings/ci.py
+++ b/tests/test_project/settings/ci.py
@@ -19,4 +19,13 @@ DATABASES = {
         "HOST": "localhost",
         "PORT": "5432",
     },
+    "schema_db": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("DB_NAME_WEATHER", "schemadb"),
+        "USER": os.environ.get("DB_USER", "postgres"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", "postgres"),
+        "HOST": "localhost",
+        "PORT": "5432",
+        "OPTIONS": {"options": "-c search_path=other"},
+    },
 }

--- a/tests/test_project/viewtest/tests.py
+++ b/tests/test_project/viewtest/tests.py
@@ -240,9 +240,9 @@ class ViewTestCase(TestCase):
         call_command("sync_pgviews", update=False)
 
         # All views went through syncing
-        self.assertEqual(len(synced_views), 13)
         self.assertEqual(all_views_were_synced[0], True)
         self.assertFalse(expected)
+        self.assertEqual(len(synced_views), 12)
 
     def test_get_sql(self):
         User.objects.create(username="old", is_superuser=True, date_joined=timezone.now() - timedelta(days=10))

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps=
     dj42: https://github.com/django/django/archive/stable/4.2.x.tar.gz#egg=django
     dj50: https://github.com/django/django/archive/stable/5.0.x.tar.gz#egg=django
 commands=
-    python manage.py test  {posargs:test_project.viewtest test_project.multidbtest}
+    python manage.py test {posargs:test_project.viewtest test_project.multidbtest test_project.schemadbtest} -v2
 passenv =
     DB_NAME
     DB_USER


### PR DESCRIPTION
The recommended method for positioning a view in a PostgreSQL schema other than 'public' is by using the 'db_table' attribute within the 'Meta' class: `db_table = 'my_custom_schema.preferredcustomer'`.

Nevertheless, this method does not function effectively and can cause complex ORM queries to fail with an error. You can find more in-depth discussions about this issue in the following StackOverflow threads:
* [Django and postgresql schemas](https://stackoverflow.com/questions/50819748/django-and-postgresql-schemas)
* [How to use schemas in Django?](https://stackoverflow.com/questions/1160598/how-to-use-schemas-in-django)

The topics above recommend specifying schema like that: `db_table = 'schema\".\"tablename'`. Although this approach works well with Django in the scenarios I tested, it is hacky and leads to failure in view creation when using `django-pgviews-redux`.

This pull request aims to address the problem by altering the SQL queries generated by the package to exclude schema specification unless explicitly defined. As a result, the search_path connection option is prioritized, enabling the creation of views in the anticipated schemas.